### PR TITLE
Add z precision prefix to format strings

### DIFF
--- a/os/lib/dbg-io/strformat.c
+++ b/os/lib/dbg-io/strformat.c
@@ -373,6 +373,17 @@ format_str_v(const strformat_context_t *ctxt, const char *format, va_list ap)
       } else {
         flags |= SIZE_SHORT;
       }
+    } else if(*pos == 'z') {
+      if(sizeof(size_t) == sizeof(short)) {
+        flags |= SIZE_SHORT;
+      } else if(sizeof(size_t) == sizeof(long)) {
+        flags |= SIZE_LONG;
+#ifdef HAVE_LONGLONG
+      } else if (sizeof(size_t) == sizeof(long long)) {
+        flags |= SIZE_LONGLONG;
+      }
+#endif
+      pos++;
     }
 
     /* parse conversion specifier */


### PR DESCRIPTION
The z precision prefix is very useful when formatting values of type
size_t. It is part of the C99 standard.

Therefore, add support for this prefix in the function format_str_v() which is used when formatting strings, for example when logging.